### PR TITLE
query and store glue policies with refresh operation

### DIFF
--- a/app/models/data_stores/contract_holder_subject.rb
+++ b/app/models/data_stores/contract_holder_subject.rb
@@ -1,17 +1,32 @@
 # frozen_string_literal: true
 
 module DataStores
+  # A model to persist a DataStore synchronization subjects
   class ContractHolderSubject
     include Mongoid::Document
     include Mongoid::Timestamps
-    include DataStores::Transactable
+    # include DataStores::Transactable
 
-    belongs_to :contract_holder_sync, counter_cache: true
+    belongs_to :contract_holder_sync, class_name: 'DataStores::ContractHolderSyncJob', counter_cache: true
 
     field :primary_person_hbx_id, type: String
     field :subscriber_policies, type: Array
     field :responsible_party_policies, type: Array
 
     index({ primary_person_hbx_id: 1 })
+
+    scope :by_primary_hbx_id, ->(hbx_id) { where(primary_person_hbx_id: hbx_id) }
+
+    def subscriber_policies=(policies)
+      return if subscriber_policies.present? || policies.blank?
+
+      write_attribute(:subscriber_policies, policies.uniq)
+    end
+
+    def responsible_party_policies=(policies)
+      return if responsible_party_policies.present? || policies.blank?
+
+      write_attribute(:responsible_party_policies, policies.uniq)
+    end
   end
 end

--- a/app/models/data_stores/contract_holder_subject.rb
+++ b/app/models/data_stores/contract_holder_subject.rb
@@ -5,13 +5,13 @@ module DataStores
   class ContractHolderSubject
     include Mongoid::Document
     include Mongoid::Timestamps
-    # include DataStores::Transactable
+    include DataStores::Transactable
 
     belongs_to :contract_holder_sync, class_name: 'DataStores::ContractHolderSyncJob', counter_cache: true
 
     field :primary_person_hbx_id, type: String
-    field :subscriber_policies, type: Array
-    field :responsible_party_policies, type: Array
+    field :subscriber_policies, type: Array, default: -> { [] }
+    field :responsible_party_policies, type: Array, default: -> { [] }
 
     index({ primary_person_hbx_id: 1 })
 

--- a/app/models/data_stores/contract_holder_subject.rb
+++ b/app/models/data_stores/contract_holder_subject.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module DataStores
+  class ContractHolderSubject
+    include Mongoid::Document
+    include Mongoid::Timestamps
+    include DataStores::Transactable
+
+    belongs_to :contract_holder_sync, counter_cache: true
+
+    field :primary_person_hbx_id, type: String
+    field :subscriber_policies, type: Array
+    field :responsible_party_policies, type: Array
+
+    index({ primary_person_hbx_id: 1 })
+  end
+end

--- a/app/models/data_stores/contract_holder_sync_job.rb
+++ b/app/models/data_stores/contract_holder_sync_job.rb
@@ -16,6 +16,7 @@ module DataStores
     field :status, type: Symbol
     field :started_at, type: DateTime, default: -> { Time.now }
     field :completed_at, type: DateTime
+    field :error_messages, type: Array, default: -> { [] }
 
     index({ time_span_end: -1 })
 

--- a/app/models/data_stores/contract_holder_sync_job.rb
+++ b/app/models/data_stores/contract_holder_sync_job.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module DataStores
+  # A model to persist a DataStore synchronization job, its current state and transactions
+  class ContractHolderSyncJob
+    include Mongoid::Document
+    include Mongoid::Timestamps
+
+    has_many :subjects, class_name: 'DataStores::ContractHolderSubject'
+
+    # Time boundary parameters for the job
+    field :time_span_start, type: DateTime
+    field :time_span_end, type: DateTime
+
+    # State for the job
+    field :status, type: Symbol
+    field :started_at, type: DateTime, default: -> { Time.now }
+    field :completed_at, type: DateTime
+
+    index({ time_span_end: -1 })
+
+    scope :lastest_end_date, -> { order_by(time_span_end: -1).first }
+    scope :exceptions, -> { exists?('subjects.errors': true) }
+
+    # All subject_entries successfully processed
+    def is_complete?
+      # code here
+    end
+
+    def exceptions; end
+
+    private
+
+    # Guard for start dates in the future and those that precede a prior sync operation
+    def validate_time_span_start
+      start_at = [[time_span_start, Time.now].min, lastest_end_date].max
+      write_attribute(:time_span_start, start_at)
+    end
+
+    # Guard for end dates in the future that if persisted will result in time gaps due to
+    # time_span_start validation
+    def validate_time_span_end
+      end_at = [end_at, Time.now].min
+      write_attribute(:time_span_end, end_at)
+    end
+
+    def validate_time_span
+      time_span_sttart < time_span_end
+    end
+  end
+end

--- a/app/models/data_stores/transactable.rb
+++ b/app/models/data_stores/transactable.rb
@@ -1,68 +1,62 @@
 # frozen_string_literal: true
 
 module DataStores
+  # A list of valid status values.  Override defaults using initializer options
+  # acked: acknowledged
+  # completed: processing of the object finished
+  # nacked: negative_acknowledged, an outside service completed processing and indicated an error
+  # pending: awaiting processing
+  DEFAULT_STATUS_KINDS = %i[
+    acked
+    completed
+    denied
+    errored
+    excluded
+    expired
+    failed
+    nacked
+    pending
+    processing
+    submitted
+    successful
+    transmitted
+  ].freeze
+
   # A single workflow event instance for transmission to an external service
   module Transactable
-    # A list of valid status values.  Override defaults using initializer options
-    # acked: acknowledged
-    # completed: processing of the object finished
-    # nacked: negative_acknowledged, an outside service completed processing and indicated an error
-    # pending: awaiting processing
-    DEFAULT_STATUS_KINDS = %i[
-      acked
-      completed
-      denied
-      errored
-      excluded
-      expired
-      failed
-      nacked
-      pending
-      submitted
-      successful
-      transmitted
-    ].freeze
-
     extend ActiveSupport::Concern
 
     included do
-      belongs_to :account, class_name: 'Accounts::Account'
+      belongs_to :account, class_name: 'Accounts::Account', optional: true
 
-      embeds_one :request_event, class_name: 'Integrations::Event'
-      embeds_one :response_event, class_name: 'Integrations::Event'
-
-      field :command_class_name, type: String
+      embeds_one :request_event, class_name: '::Integrations::Event'
+      embeds_one :response_event, class_name: '::Integrations::Event'
 
       field :acknowledged_at, type: DateTime
       field :status, type: Symbol
 
-      # field :started_at, type: DateTime, default: -> { Time.now }
-      field :completed_at, type: DateTime
+      # # TODO: submitted when triggered event to enroll
+      # # errored/completed up on processing the response from enroll
 
-      # delegate :started_at_timestamp, to: :request_event_timestamp
-      # delegate :ended_at, to: :response_event,
+      # # field :started_at, type: DateTime, default: -> { Time.now }
+      # # field :completed_at, type: DateTime # TODO: make this a scope
 
-      # def initialize(args)
-      #   super
-      #   @status_kinds = options[:status_kinds] || DEFAULT_STATUS_KINDS
-      # end
+      # # delegate :started_at_timestamp, to: :request_event_timestamp
+      # # delegate :ended_at, to: :response_event,
 
       def status=(value)
-        raise ArgumentError "must be one of: #{@status_kinds}" unless @status_kinds.includes?(value)
-
+        # raise ArgumentError "must be one of: #{@status_kinds}" unless @status_kinds.includes?(value)
         write_attribute(:status, value)
       end
 
-      def errors; end
-
-      def exceptions; end
+      # def errors; end # TODO: create a scope
+      # def exceptions; end
     end
 
     # add scopes to query requests event not triggered, response events not received
     class_methods do
       # scope :started_at, -> { ('request_event.timestamp': true) }
       # scope :valid?, -> { ('request_event.errors': true) }
-
       # scope :transactions_completed, -> { exists?('response_event.timestamp': false) }
     end
   end

--- a/app/models/data_stores/transactable.rb
+++ b/app/models/data_stores/transactable.rb
@@ -42,10 +42,10 @@ module DataStores
       # delegate :started_at_timestamp, to: :request_event_timestamp
       # delegate :ended_at, to: :response_event,
 
-      def initialize(args)
-        super
-        @status_kinds = options[:status_kinds] || DEFAULT_STATUS_KINDS
-      end
+      # def initialize(args)
+      #   super
+      #   @status_kinds = options[:status_kinds] || DEFAULT_STATUS_KINDS
+      # end
 
       def status=(value)
         raise ArgumentError "must be one of: #{@status_kinds}" unless @status_kinds.includes?(value)

--- a/app/models/data_stores/transactable.rb
+++ b/app/models/data_stores/transactable.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module DataStores
+  # A single workflow event instance for transmission to an external service
+  module Transactable
+    # A list of valid status values.  Override defaults using initializer options
+    # acked: acknowledged
+    # completed: processing of the object finished
+    # nacked: negative_acknowledged, an outside service completed processing and indicated an error
+    # pending: awaiting processing
+    DEFAULT_STATUS_KINDS = %i[
+      acked
+      completed
+      denied
+      errored
+      excluded
+      expired
+      failed
+      nacked
+      pending
+      submitted
+      successful
+      transmitted
+    ].freeze
+
+    extend ActiveSupport::Concern
+
+    included do
+      belongs_to :account, class_name: 'Accounts::Account'
+
+      embeds_one :request_event, class_name: 'Integrations::Event'
+      embeds_one :response_event, class_name: 'Integrations::Event'
+
+      field :command_class_name, type: String
+
+      field :acknowledged_at, type: DateTime
+      field :status, type: Symbol
+
+      # field :started_at, type: DateTime, default: -> { Time.now }
+      field :completed_at, type: DateTime
+
+      # delegate :started_at_timestamp, to: :request_event_timestamp
+      # delegate :ended_at, to: :response_event,
+
+      def initialize(args)
+        super
+        @status_kinds = options[:status_kinds] || DEFAULT_STATUS_KINDS
+      end
+
+      def status=(value)
+        raise ArgumentError "must be one of: #{@status_kinds}" unless @status_kinds.includes?(value)
+
+        write_attribute(:status, value)
+      end
+
+      def errors; end
+
+      def exceptions; end
+    end
+
+    # add scopes to query requests event not triggered, response events not received
+    class_methods do
+      # scope :started_at, -> { ('request_event.timestamp': true) }
+      # scope :valid?, -> { ('request_event.errors': true) }
+
+      # scope :transactions_completed, -> { exists?('response_event.timestamp': false) }
+    end
+  end
+end

--- a/app/models/integrations/event.rb
+++ b/app/models/integrations/event.rb
@@ -11,7 +11,15 @@ module Integrations
     field :name, type: String
     field :body, type: String
     field :status, type: String
-    field :errors, type: Array
+    field :error_messages, type: Array
     field :timestamp, type: DateTime, default: -> { Time.now }
+
+    def transmitted?
+      status == :transmitted
+    end
+
+    def errored?
+      status == :errored
+    end
   end
 end

--- a/app/models/integrations/event.rb
+++ b/app/models/integrations/event.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Integrations
+  # A single workflow event instance for transmission to an external service
+  class Event
+    include Mongoid::Document
+    include Mongoid::Timestamps
+
+    embeds_one :head
+
+    field :name, type: String
+    field :body, type: String
+    field :status, type: String
+    field :errors, type: Array
+    field :timestamp, type: DateTime, default: -> { Time.now }
+  end
+end

--- a/app/models/integrations/head.rb
+++ b/app/models/integrations/head.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Integrations
+  # A single workflow event instance for transmission to an external service
+  class Head
+    include Mongoid::Document
+    include Mongoid::Timestamps
+
+    DEFAULT_HEADERS = { correlation_id: 'string', length: 'integer' }.freeze
+
+    embeds_many :variables, as: :headers
+  end
+end

--- a/app/models/integrations/variable.rb
+++ b/app/models/integrations/variable.rb
@@ -7,7 +7,7 @@ module Integrations
     include Mongoid::Timestamps
 
     field :name, type: String
-    field :data_type, type: StringifiedHash
+    field :data_type, type: String # StringifiedHash
     field :value, type: String
   end
 end

--- a/app/models/integrations/variable.rb
+++ b/app/models/integrations/variable.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Integrations
+  # A single workflow event instance for transmission to an external service
+  class Variable
+    include Mongoid::Document
+    include Mongoid::Timestamps
+
+    field :name, type: String
+    field :data_type, type: StringifiedHash
+    field :value, type: String
+  end
+end

--- a/app/operations/data_stores/contract_holder_subjects/create_or_update.rb
+++ b/app/operations/data_stores/contract_holder_subjects/create_or_update.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'dry/monads'
+require 'dry/monads/do'
+
+module DataStores
+  module ContractHolderSubjects
+    # Operation to create Enrollments.
+    class CreateOrUpdate
+      send(:include, Dry::Monads[:result, :do])
+
+      def call(params)
+        values   = yield validate(params)
+        sync_job = yield find_contract_holder_sync_job(values)
+        subject  = yield create_or_update_subject(sync_job, values)
+
+        Success(subject)
+      end
+
+      private
+
+      def validate(params)
+        errors = []
+        errors << "contract_holder_sync_job required" unless params[:contract_holder_sync_job_id]
+        errors << "primary hbx id" unless params[:primary_person_hbx_id]
+        if params[:subscriber_policies].blank? && params[:responsible_party_policies].blank?
+          errors << "at least one of subscriber or responsible party policies required"
+        end
+
+        errors.present? ? Failure(errors) : Success(params)
+      end
+
+      def create_or_update_subject(sync_job, values)
+        subject = find_subject(sync_job, values)
+        subject ||= sync_job.subjects.build(primary_person_hbx_id: values[:primary_person_hbx_id])
+        subject.subscriber_policies = values[:subscriber_policies]
+        subject.responsible_party_policies = values[:responsible_party_policies]
+
+        if subject.save
+          Success(subject)
+        else
+          Failure(subject.errors.to_h)
+        end
+      end
+
+      def find_contract_holder_sync_job(values)
+        sync_job = DataStores::ContractHolderSyncJob.find(values[:contract_holder_sync_job_id])
+        return Failure("unable to find sync job with id #{values[:contract_holder_sync_job_id]}") unless sync_job
+
+        Success(sync_job)
+      end
+
+      def find_subject(sync_job, values)
+        sync_job.subjects.by_primary_hbx_id(values[:primary_person_hbx_id]).first
+      end
+    end
+  end
+end

--- a/app/operations/data_stores/contract_holder_subjects/create_or_update.rb
+++ b/app/operations/data_stores/contract_holder_subjects/create_or_update.rb
@@ -5,14 +5,15 @@ require 'dry/monads/do'
 
 module DataStores
   module ContractHolderSubjects
-    # Operation to create Enrollments.
+    # Operation to create or update ContractHolderSubjects
     class CreateOrUpdate
       send(:include, Dry::Monads[:result, :do])
+      include EventSource::Command
 
       def call(params)
-        values   = yield validate(params)
-        sync_job = yield find_contract_holder_sync_job(values)
-        subject  = yield create_or_update_subject(sync_job, values)
+        values  = yield validate(params)
+        subject = yield create_or_update_subject(values)
+        output  = yield publish_event(subject)
 
         Success(subject)
       end
@@ -21,7 +22,7 @@ module DataStores
 
       def validate(params)
         errors = []
-        errors << "contract_holder_sync_job required" unless params[:contract_holder_sync_job_id]
+        errors << "contract_holder_sync_job required" unless params[:contract_holder_sync_job]
         errors << "primary hbx id" unless params[:primary_person_hbx_id]
         if params[:subscriber_policies].blank? && params[:responsible_party_policies].blank?
           errors << "at least one of subscriber or responsible party policies required"
@@ -30,9 +31,9 @@ module DataStores
         errors.present? ? Failure(errors) : Success(params)
       end
 
-      def create_or_update_subject(sync_job, values)
-        subject = find_subject(sync_job, values)
-        subject ||= sync_job.subjects.build(primary_person_hbx_id: values[:primary_person_hbx_id])
+      def create_or_update_subject(values)
+        subject = find_subject(values)
+        subject ||= values[:contract_holder_sync_job].subjects.build(primary_person_hbx_id: values[:primary_person_hbx_id])
         subject.subscriber_policies = values[:subscriber_policies]
         subject.responsible_party_policies = values[:responsible_party_policies]
 
@@ -43,15 +44,41 @@ module DataStores
         end
       end
 
-      def find_contract_holder_sync_job(values)
-        sync_job = DataStores::ContractHolderSyncJob.find(values[:contract_holder_sync_job_id])
-        return Failure("unable to find sync job with id #{values[:contract_holder_sync_job_id]}") unless sync_job
+      def publish_event(subject)
+        return Success(subject) if subject.request_event&.transmitted?
 
-        Success(sync_job)
+        event_name = "events.families.find_by_requested"
+        event_payload = { person_hbx_id: subject.primary_person_hbx_id }.to_json
+        event = event(event_name, attributes: event_payload)
+        event.success.publish
+        logger.info("published family refresh event for #{subject.primary_person_hbx_id} at #{DateTime.now}")
+        persist_request_event(subject, event_name, event_payload)
+        Success("published family refresh event for #{subject.primary_person_hbx_id} at #{DateTime.now}")
+      rescue StandardError => e
+        logger.info("unable to publish family refresh for #{subject.primary_person_hbx_id} due to #{e.inspect}")
+        persist_request_event(subject, event_name, event_payload, [e.to_s])
+        Failure("unable to publish family refresh for #{subject.primary_person_hbx_id} due to #{e.inspect}")
       end
 
-      def find_subject(sync_job, values)
+      def persist_request_event(subject, event_name, event_payload, errors = [])
+        request_event = Integrations::Events::Build.new.call({
+                                                               name: event_name,
+                                                               body: event_payload,
+                                                               errors: errors
+                                                             }).success
+
+        subject.update(request_event: request_event)
+      end
+
+      def find_subject(values)
+        sync_job = values[:contract_holder_sync_job]
         sync_job.subjects.by_primary_hbx_id(values[:primary_person_hbx_id]).first
+      end
+
+      def logger
+        return @logger if defined? @logger
+
+        @logger = Logger.new("#{Rails.root}/log/subject_create_or_update_#{Date.today.strftime('%Y_%m_%d')}.log")
       end
     end
   end

--- a/app/operations/data_stores/contract_holder_sync_jobs/create.rb
+++ b/app/operations/data_stores/contract_holder_sync_jobs/create.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'dry/monads'
+require 'dry/monads/do'
+
+module DataStores
+  module ContractHolderSyncJobs
+    # Operation to create ContractHolderSyncJob
+    class Create
+      send(:include, Dry::Monads[:result, :do])
+
+      # @param [Hash] params the parameters used to create a new job
+      # @return [Dry::Monad::Success] Sync job created
+      # @return [Dry::Monad::Failure] failed to create Sync job
+      def call(params)
+        values = yield validate(params)
+        # sync_job = yield find_contract_holder_sync_job(values)
+        sync_job = yield create(values)
+
+        Success(sync_job)
+      end
+
+      private
+
+      def validate(params)
+        errors = []
+        errors << "start_time is required" unless params[:start_time]
+        errors << "end_time is required" unless params[:end_time]
+        errors << "status is required" unless params[:status]
+
+        errors.present? ? Failure(errors) : Success(params)
+      end
+
+      def create(values)
+        sync_job = DataStores::ContractHolderSyncJob.create(
+          time_span_start: values[:start_time],
+          time_span_end: values[:end_time],
+          status: values[:status]
+        )
+
+        Success(sync_job)
+      end
+    end
+  end
+end

--- a/app/operations/insurance_policies/glue_policy_query.rb
+++ b/app/operations/insurance_policies/glue_policy_query.rb
@@ -11,69 +11,59 @@ module InsurancePolicies
       @end_time = end_time
     end
 
-    # rubocop:disable Metrics/MethodLength, Layout/LineLength
-    def by_subscriber
-      policies_by_subscriber = Policy.collection.raw_aggregate([
-                                                                 { "$match" => {
-                                                                   :created_at => { "$gte" => @start_time, "$lte" => @end_time },
-                                                                   :responsible_party_id => { "$exists" => false }
-                                                                 } },
-                                                                 { "$unwind" => "$enrollees" },
-                                                                 { "$match" => { "enrollees.rel_code" => "self" } },
-                                                                 { "$project" => { "cancelled" => {
-                                                                                     "$eq" => ["$enrollees.coverage_start", "$enrollees.coverage_end"]
-                                                                                   },
-                                                                                   "subscriber_id" => "$enrollees.m_id", "eg_id" => "$eg_id" } },
-                                                                 { "$match" => { "cancelled" => false } },
-                                                                 { "$group" => {
-                                                                   "_id" => "$subscriber_id",
-                                                                   "enrolled_policies" => { "$addToSet" => "$eg_id" }
-                                                                 } }
-                                                               ])
-
-      policies_by_subscriber.each do |_record|
-        yield
-      end
+    def group_by_subscriber_query
+      Policy.collection.raw_aggregate([
+                                        { "$match" => {
+                                          :updated_at => { "$gte" => @start_time, "$lte" => @end_time },
+                                          :responsible_party_id => { "$exists" => false }
+                                        } },
+                                        { "$unwind" => "$enrollees" },
+                                        { "$match" => { "enrollees.rel_code" => "self" } },
+                                        { "$project" => {
+                                          #  "cancelled" => {
+                                          #    "$eq" => ["$enrollees.coverage_start", "$enrollees.coverage_end"]
+                                          #  },
+                                          "subscriber_id" => "$enrollees.m_id", "eg_id" => "$eg_id"
+                                        } },
+                                        #  { "$match" => { "cancelled" => false } },
+                                        { "$group" => {
+                                          "_id" => "$subscriber_id",
+                                          "enrolled_policies" => { "$addToSet" => "$eg_id" }
+                                        } }
+                                      ])
     end
 
-    def by_responsible_party
-      responsible_party_policies = Policy.collection.raw_aggregate([
-                                                                     { "$match" => {
-                                                                       :created_at => { "$gte" => @start_time,
-                                                                                        "$lte" => @end_time },
-                                                                       :responsible_party_id => { "$exists" => true }
-                                                                     } },
-                                                                     { "$unwind" => "$enrollees" },
-                                                                     { "$match" => { "enrollees.rel_code" => "self" } },
-                                                                     { "$project" => { "cancelled" => {
-                                                                                         "$eq" => ["$enrollees.coverage_start", "$enrollees.coverage_end"]
-                                                                                       },
-                                                                                       "subscriber_id" => "$responsible_party_id", "eg_id" => "$eg_id" } },
-                                                                     { "$match" => { "cancelled" => false } },
-                                                                     { "$group" => {
-                                                                       "_id" => "$subscriber_id",
-                                                                       "enrolled_policies" => { "$addToSet" => "$eg_id" }
-                                                                     } }
-                                                                   ])
-
-      responsible_party_people(responsible_party_policies)
-      responsible_party_policies.each do |_record|
-        yield
-      end
+    # rubocop:disable Metrics/MethodLength
+    def policies_by_subscriber(&block)
+      group_by_subscriber_query.each(&block)
     end
-    # rubocop:enable Metrics/MethodLength, Layout/LineLength
 
-    def responsible_party_people(responsible_party_policies)
-      return @responsible_party_people if defined? @responsible_party_people
-
-      responsible_people = Person.where(:'responsible_parties._id'.in => responsible_party_policies.collect do |record|
-                                                                           record['_id']
-                                                                         end)
-      @responsible_party_people = responsible_people.each_with_object({}) do |person, data|
-        person.responsible_parties.each do |responsible_party|
-          data[responsible_party.id] = person.authority_member_id
-        end
-      end
+    def group_by_responsible_party_query
+      Policy.collection.raw_aggregate([
+                                        { "$match" => {
+                                          :updated_at => { "$gte" => @start_time,
+                                                           "$lte" => @end_time },
+                                          :responsible_party_id => { "$exists" => true }
+                                        } },
+                                        { "$unwind" => "$enrollees" },
+                                        { "$match" => { "enrollees.rel_code" => "self" } },
+                                        { "$project" => {
+                                          #  "cancelled" => {
+                                          #    "$eq" => ["$enrollees.coverage_start", "$enrollees.coverage_end"]
+                                          #  },
+                                          "subscriber_id" => "$responsible_party_id", "eg_id" => "$eg_id"
+                                        } },
+                                        { "$match" => { "cancelled" => false } },
+                                        { "$group" => {
+                                          "_id" => "$subscriber_id",
+                                          "enrolled_policies" => { "$addToSet" => "$eg_id" }
+                                        } }
+                                      ])
     end
+
+    def policies_by_responsible_party(&block)
+      group_by_responsible_party_query.each(&block)
+    end
+    # rubocop:enable Metrics/MethodLength
   end
 end

--- a/app/operations/insurance_policies/glue_policy_query.rb
+++ b/app/operations/insurance_policies/glue_policy_query.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'dry/monads'
+require 'dry/monads/do'
+
+module InsurancePolicies
+  # Queries glue policies by subscriber and responsible party
+  class GluePolicyQuery
+    def initialize(start_time, end_time)
+      @start_time = start_time
+      @end_time = end_time
+    end
+
+    # rubocop:disable Metrics/MethodLength, Layout/LineLength
+    def by_subscriber
+      policies_by_subscriber = Policy.collection.raw_aggregate([
+                                                                 { "$match" => {
+                                                                   :created_at => { "$gte" => @start_time, "$lte" => @end_time },
+                                                                   :responsible_party_id => { "$exists" => false }
+                                                                 } },
+                                                                 { "$unwind" => "$enrollees" },
+                                                                 { "$match" => { "enrollees.rel_code" => "self" } },
+                                                                 { "$project" => { "cancelled" => {
+                                                                                     "$eq" => ["$enrollees.coverage_start", "$enrollees.coverage_end"]
+                                                                                   },
+                                                                                   "subscriber_id" => "$enrollees.m_id", "eg_id" => "$eg_id" } },
+                                                                 { "$match" => { "cancelled" => false } },
+                                                                 { "$group" => {
+                                                                   "_id" => "$subscriber_id",
+                                                                   "enrolled_policies" => { "$addToSet" => "$eg_id" }
+                                                                 } }
+                                                               ])
+
+      policies_by_subscriber.each do |_record|
+        yield
+      end
+    end
+
+    def by_responsible_party
+      responsible_party_policies = Policy.collection.raw_aggregate([
+                                                                     { "$match" => {
+                                                                       :created_at => { "$gte" => @start_time,
+                                                                                        "$lte" => @end_time },
+                                                                       :responsible_party_id => { "$exists" => true }
+                                                                     } },
+                                                                     { "$unwind" => "$enrollees" },
+                                                                     { "$match" => { "enrollees.rel_code" => "self" } },
+                                                                     { "$project" => { "cancelled" => {
+                                                                                         "$eq" => ["$enrollees.coverage_start", "$enrollees.coverage_end"]
+                                                                                       },
+                                                                                       "subscriber_id" => "$responsible_party_id", "eg_id" => "$eg_id" } },
+                                                                     { "$match" => { "cancelled" => false } },
+                                                                     { "$group" => {
+                                                                       "_id" => "$subscriber_id",
+                                                                       "enrolled_policies" => { "$addToSet" => "$eg_id" }
+                                                                     } }
+                                                                   ])
+
+      responsible_party_people(responsible_party_policies)
+      responsible_party_policies.each do |_record|
+        yield
+      end
+    end
+    # rubocop:enable Metrics/MethodLength, Layout/LineLength
+
+    def responsible_party_people(responsible_party_policies)
+      return @responsible_party_people if defined? @responsible_party_people
+
+      responsible_people = Person.where(:'responsible_parties._id'.in => responsible_party_policies.collect do |record|
+                                                                           record['_id']
+                                                                         end)
+      @responsible_party_people = responsible_people.each_with_object({}) do |person, data|
+        person.responsible_parties.each do |responsible_party|
+          data[responsible_party.id] = person.authority_member_id
+        end
+      end
+    end
+  end
+end

--- a/app/operations/insurance_policies/refresh.rb
+++ b/app/operations/insurance_policies/refresh.rb
@@ -1,39 +1,126 @@
 # frozen_string_literal: true
 
+require 'dry/monads'
+require 'dry/monads/do'
+
 module InsurancePolicies
-  # Process 'enroll.insurance_policies.refresh_requested' event
+  # this will capture all the exceptions occurred during the process
+  class ErrorHandler
+    attr_reader :errors
+
+    def initialize
+      @errors = []
+    end
+
+    def capture_exception
+      yield
+    rescue StandardError => e
+      @errors << e.to_s
+    end
+  end
+
+  # Persist contract holder sync job with subjects into the database
   class Refresh
-    include Dry::Monads[:result, :do]
-    include EventSource::Command
+    send(:include, Dry::Monads[:result, :do])
 
-    # TODO: Implement business logic
+    attr_reader :error_handler
+
     def call(params)
-      refresh_period = yield validate(params)
-      event          = yield build_event(refresh_period)
-      result         = yield publish(event)
+      values       = yield validate(params)
+      sync_job     = yield create_sync_job(values)
+      query        = yield create_new_query(values)
+      _policies    = yield persist_subscriber_policies(sync_job, query)
+      _rp_policies = yield persist_responsible_party_policies(sync_job, query)
+      sync_job     = yield close_sync_job(sync_job)
 
-      Success(result)
+      Success(sync_job)
     end
 
     private
 
-    def build_event(_refresh_period)
-      event('events.families.find_by_requested', attributes: {})
-    end
-
-    def parsed_refresh_period(params)
-      Range.new(*params['refresh_period'].split('..').map(&:to_time))
-    end
-
-    def publish(event)
-      event.publish
-      Success("Successfully published event: #{event.name}")
-    end
-
     def validate(params)
-      Success(
-        parsed_refresh_period(params)
-      )
+      return Failure("start_time is required") unless params[:start_time].present?
+      return Failure("end_time is required") unless params[:end_time].present?
+
+      @error_handler = ErrorHandler.new
+
+      Success(params)
+    end
+
+    def create_sync_job(values)
+      job_params = values.slice(:start_time, :end_time)
+      job_params[:status] = :processing
+
+      DataStores::ContractHolderSyncJobs::Create.new.call(job_params)
+    end
+
+    def create_new_query(values)
+      query = GluePolicyQuery.new(values[:start_time], values[:end_time])
+
+      Success(query)
+    end
+
+    def persist_subscriber_policies(sync_job, policy_query)
+      policy_query.policies_by_subscriber do |result|
+        @error_handler.capture_exception do
+          subject_create_or_update({
+                                     contract_holder_sync_job: sync_job,
+                                     primary_person_hbx_id: result["_id"],
+                                     subscriber_policies: result["enrolled_policies"]
+                                   })
+        end
+      end
+
+      Success(true)
+    end
+
+    def persist_responsible_party_policies(sync_job, policy_query)
+      policy_query.policies_by_responsible_party do |result|
+        @error_handler.capture_exception do
+          responsible_person = responsible_party_person_for(result['_id'])
+          raise "unable to find person record for with responsible party #{result['_id']}" unless responsible_person
+
+          subject_create_or_update({
+                                     contract_holder_sync_job: sync_job,
+                                     primary_person_hbx_id: responsible_person.authority_member_id,
+                                     responsible_party_policies: result["enrolled_policies"]
+                                   })
+        end
+      end
+
+      Success(true)
+    end
+
+    def subject_create_or_update(options)
+      response = DataStores::ContractHolderSubjects::CreateOrUpdate.new.call(options)
+      raise response.failure if response.failure?
+    end
+
+    def close_sync_job(sync_job)
+      status = :transmitted
+      status = :errored if @error_handler.errors.present?
+      sync_job.update(status: status, error_messages: @error_handler.errors)
+
+      Success(sync_job)
+    end
+
+    def responsible_party_person_for(responsible_party_id)
+      Person.where(:'responsible_parties._id' => responsible_party_id).first
     end
   end
 end
+
+#
+# params: datetime range
+#     calculate_date_range
+#     start_date max of the parameter start date and refresh end date
+#     end_date is min of the parameter end date and datetime now
+#        if end date is less than refresh end date (nothing to do)
+
+#  query gluedb for policies and primary person with given datetime range
+#    - query for policies create or updated
+
+#  persist as transactions in refresh table (by primary person)
+#  fire events to request enroll family cv for each primary applicant
+#  query glue policies with date time range
+#  trigger enroll refresh for each family

--- a/app/operations/integrations/events/build.rb
+++ b/app/operations/integrations/events/build.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'dry/monads'
+require 'dry/monads/do'
+
+module Integrations
+  module Events
+    # Operation to build Integrations Event
+    class Build
+      send(:include, Dry::Monads[:result, :do])
+
+      # @param [Hash] params the parameters to build new event
+      # @return [Dry::Monad::Success] event instance
+      # @return [Dry::Monad::Failure] failed with validation errors
+      def call(params)
+        values = yield validate(params)
+        event = yield build(values)
+
+        Success(event)
+      end
+
+      private
+
+      def validate(params)
+        errors = []
+        errors << "name is required" unless params[:name]
+        errors << "body is required" unless params[:body]
+        params[:errors] ||= []
+        errors << "errors array expected" unless params[:errors].is_a?(Array)
+
+        errors.blank? ? Success(params) : Failure(errors)
+      end
+
+      def build(values)
+        attributes = values.slice(:name, :body)
+        attributes[:error_messages] = values[:errors]
+        attributes[:status] = values[:errors].present? ? :errored : :transmitted
+
+        Success(Integrations::Event.new(attributes))
+      end
+    end
+  end
+end

--- a/spec/factories/data_stores/contract_holder_subjects.rb
+++ b/spec/factories/data_stores/contract_holder_subjects.rb
@@ -5,4 +5,3 @@ FactoryBot.define do
     sequence(:primary_person_hbx_id)
   end
 end
-  

--- a/spec/factories/data_stores/contract_holder_subjects.rb
+++ b/spec/factories/data_stores/contract_holder_subjects.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :contract_holder_subject, class: DataStores::ContractHolderSubject do
+    sequence(:primary_person_hbx_id)
+  end
+end
+  

--- a/spec/factories/data_stores/contract_holder_sync_jobs.rb
+++ b/spec/factories/data_stores/contract_holder_sync_jobs.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :contract_holder_sync_job, class: DataStores::ContractHolderSyncJob do
+    started_at { DateTime.now }
+    completed_at { DateTime.now + 6.hours }
+  end
+end

--- a/spec/operations/data_stores/contract_holder_subjects/create_or_update_spec.rb
+++ b/spec/operations/data_stores/contract_holder_subjects/create_or_update_spec.rb
@@ -28,8 +28,13 @@ RSpec.describe DataStores::ContractHolderSubjects::CreateOrUpdate do
       }
     end
 
+    let(:event_detail) do
+      double(name: 'events.families.find_by_requested', payload: { person_hbx_id: person.authority_member_id }.to_json,
+             publish: true)
+    end
+
     let(:request_event) do
-      double(name: 'events.families.find_by_requested', payload: "hello world!!", publish: true)
+      double(success: event_detail)
     end
 
     before do
@@ -58,8 +63,8 @@ RSpec.describe DataStores::ContractHolderSubjects::CreateOrUpdate do
         request_event_instance = @result.success.request_event
 
         expect(request_event_instance).to be_present
-        expect(request_event_instance.name).to eq request_event.name
-        expect(request_event_instance.body).to eq request_event.payload
+        expect(request_event_instance.name).to eq event_detail.name
+        expect(request_event_instance.body).to eq event_detail.payload
       end
     end
 

--- a/spec/operations/data_stores/contract_holder_subjects/create_or_update_spec.rb
+++ b/spec/operations/data_stores/contract_holder_subjects/create_or_update_spec.rb
@@ -21,11 +21,19 @@ RSpec.describe DataStores::ContractHolderSubjects::CreateOrUpdate do
 
     let(:params) do
       {
-        contract_holder_sync_job_id: contract_holder_sync_job.id,
+        contract_holder_sync_job: contract_holder_sync_job,
         primary_person_hbx_id: person.authority_member_id,
         subscriber_policies: subscriber_policies,
         responsible_party_policies: responsible_party_policies
       }
+    end
+
+    let(:request_event) do
+      double(name: 'events.families.find_by_requested', payload: "hello world!!", publish: true)
+    end
+
+    before do
+      allow(subject).to receive(:event).and_return(request_event)
     end
 
     context 'and new primary person' do
@@ -45,6 +53,14 @@ RSpec.describe DataStores::ContractHolderSubjects::CreateOrUpdate do
         expect(@result.success.subscriber_policies).to eq subscriber_policies
         expect(@result.success.responsible_party_policies).to eq responsible_party_policies
       end
+
+      it "should store request event" do
+        request_event_instance = @result.success.request_event
+
+        expect(request_event_instance).to be_present
+        expect(request_event_instance.name).to eq request_event.name
+        expect(request_event_instance.body).to eq request_event.payload
+      end
     end
 
     context 'and existing primary person' do
@@ -55,7 +71,7 @@ RSpec.describe DataStores::ContractHolderSubjects::CreateOrUpdate do
 
       let(:updated_params) do
         {
-          contract_holder_sync_job_id: contract_holder_sync_job.id,
+          contract_holder_sync_job: contract_holder_sync_job,
           primary_person_hbx_id: person.authority_member_id,
           subscriber_policies: updated_subscriber_policies,
           responsible_party_policies: updated_responsible_party_policies

--- a/spec/operations/data_stores/contract_holder_subjects/create_or_update_spec.rb
+++ b/spec/operations/data_stores/contract_holder_subjects/create_or_update_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+RSpec.describe DataStores::ContractHolderSubjects::CreateOrUpdate do
+  subject { described_class.new }
+
+  context 'with invalid params' do
+    it "return failure" do
+      result = subject.call({})
+      expect(result.failure?).to be_truthy
+      expect(result.failure).to include "contract_holder_sync_job required"
+      expect(result.failure).to include "primary hbx id"
+      expect(result.failure).to include "at least one of subscriber or responsible party policies required"
+    end
+  end
+
+  context 'with valid params' do
+    let!(:contract_holder_sync_job) { create(:contract_holder_sync_job) }
+    let(:person) { FactoryBot.create(:person) }
+    let(:subscriber_policies) { ['55231212', '42121212'] }
+    let(:responsible_party_policies) { ['55231210', '42121210'] }
+
+    let(:params) do
+      {
+        contract_holder_sync_job_id: contract_holder_sync_job.id,
+        primary_person_hbx_id: person.authority_member_id,
+        subscriber_policies: subscriber_policies,
+        responsible_party_policies: responsible_party_policies
+      }
+    end
+
+    context 'and new primary person' do
+      before do
+        @result = subject.call(params)
+      end
+
+      it "return success" do
+        expect(@result.success?).to be_truthy
+      end
+
+      it "should create new subject" do
+        expect(@result.success.class).to be DataStores::ContractHolderSubject
+      end
+
+      it "should persist policies" do
+        expect(@result.success.subscriber_policies).to eq subscriber_policies
+        expect(@result.success.responsible_party_policies).to eq responsible_party_policies
+      end
+    end
+
+    context 'and existing primary person' do
+      let!(:contract_holder_subject) { subject.call(params.except(:responsible_party_policies)) }
+
+      let(:updated_subscriber_policies) { ['99231212', '99121212'] }
+      let(:updated_responsible_party_policies) { ['65231210', '62121210'] }
+
+      let(:updated_params) do
+        {
+          contract_holder_sync_job_id: contract_holder_sync_job.id,
+          primary_person_hbx_id: person.authority_member_id,
+          subscriber_policies: updated_subscriber_policies,
+          responsible_party_policies: updated_responsible_party_policies
+        }
+      end
+
+      before do
+        @result = subject.call(updated_params)
+      end
+
+      it "return success" do
+        expect(@result.success?).to be_truthy
+      end
+
+      it "should return updated subject" do
+        expect(@result.success.class).to be DataStores::ContractHolderSubject
+      end
+
+      it "should not update subscriber policies" do
+        expect(@result.success.subscriber_policies).to eq subscriber_policies
+      end
+
+      it "should update responsible policies" do
+        expect(@result.success.responsible_party_policies).to eq updated_responsible_party_policies
+      end
+    end
+  end
+end

--- a/spec/operations/insurance_policies/refresh_spec.rb
+++ b/spec/operations/insurance_policies/refresh_spec.rb
@@ -1,22 +1,101 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'shared_examples/cv3_family'
 
-RSpec.describe InsurancePolicies::Refresh, dbclean: :after_each do
-  subject { described_class.new.call(input_params) }
+RSpec.describe InsurancePolicies::Refresh do
+  subject { described_class.new }
+  include_context 'cv3_family'
 
-  describe '#call' do
-    context 'with valid input params' do
-      let(:input_params) { { 'refresh_period' => '02/07/2023 09:51..02/07/2023 18:51' } }
+  context 'with invalid payload' do
+    it "return failure" do
+      res = subject.call({})
+      expect(res.failure?).to be_truthy
+    end
+  end
 
-      it 'returns a success with a message' do
-        expect(
-          subject.success
-        ).to eq('Successfully published event: events.families.find_by_requested')
-      end
+  context 'with valid params' do
+    let(:start_time) { 12.hours.ago }
+    let(:end_time) { Time.now }
+    let(:params) do
+      {
+        start_time: start_time,
+        end_time: end_time
+      }
     end
 
-    # context 'with invalid input params' do
-    # end
+    let(:people_coverages) do
+      {
+        "1030800" => {
+          "subscriber_policies" => ["1190331"],
+          "responsible_party_policies" => []
+        },
+        "1025123" => { "subscriber_policies" => ["1461616", "1191217"],
+                       "responsible_party_policies" => ["1495008"] },
+        "1224990" => {
+          "subscriber_policies" => [],
+          "responsible_party_policies" => ["1605982", "1521441"]
+        }
+      }
+    end
+
+    let(:subscriber_policies) do
+      people_coverages.collect do |hbx_id, coverages|
+        { "_id" => hbx_id, "enrolled_policies" => coverages["subscriber_policies"] } if coverages["subscriber_policies"].present?
+      end.compact
+    end
+
+    let(:responsible_party_policies) do
+      people_coverages.collect do |hbx_id, coverages|
+        if coverages["responsible_party_policies"].present?
+          { "_id" => hbx_id,
+            "enrolled_policies" => coverages["responsible_party_policies"] }
+        end
+      end.compact
+    end
+
+    before do
+      allow(subject).to receive(:responsible_party_person_for).with("1025123").and_return(double(authority_member_id: "1025123"))
+      allow(subject).to receive(:responsible_party_person_for).with("1224990").and_return(double(authority_member_id: "1224990"))
+      allow_any_instance_of(InsurancePolicies::GluePolicyQuery)
+        .to receive(:group_by_subscriber_query).and_return(subscriber_policies)
+      allow_any_instance_of(InsurancePolicies::GluePolicyQuery)
+        .to receive(:group_by_responsible_party_query).and_return(responsible_party_policies)
+    end
+
+    context 'when valid time range passed' do
+      before do
+        @result = subject.call(params)
+      end
+
+      it "return success" do
+        expect(@result.success?).to be_truthy
+      end
+
+      it "should create new contract holder sync job" do
+        output = @result.success
+        expect(output.class).to be DataStores::ContractHolderSyncJob
+        expect(output.time_span_start.utc).to eq start_time.utc
+        expect(output.time_span_end.utc).to eq end_time.utc
+        expect(output.status).to be :errored
+      end
+
+      it "should create contract holder subjects with policies" do
+        output = @result.success
+        expect(output.subjects.count).to eq 3
+
+        people_coverages.each do |hbx_id, coverages|
+          subject = output.subjects.by_primary_hbx_id(hbx_id).first
+          expect(subject.subscriber_policies).to eq coverages['subscriber_policies']
+          expect(subject.responsible_party_policies).to eq coverages['responsible_party_policies']
+          expect(subject.request_event).to be_present
+          expect(subject.request_event.name).to eq "events.families.find_by_requested"
+        end
+      end
+
+      it "should not have any errors" do
+        expect(subject.error_handler.errors).to be_present
+      end
+    end
   end
 end
+

--- a/spec/operations/insurance_policies/refresh_spec.rb
+++ b/spec/operations/insurance_policies/refresh_spec.rb
@@ -98,4 +98,3 @@ RSpec.describe InsurancePolicies::Refresh do
     end
   end
 end
-


### PR DESCRIPTION
[ME-184372449](https://www.pivotaltracker.com/story/show/184372449)
[ME-184383698](https://www.pivotaltracker.com/story/show/184383698)