### PR TITLE
logging policy contract failure in rcno report rather than returning nil

### DIFF
--- a/app/operations/reports/generate_rcno_report.rb
+++ b/app/operations/reports/generate_rcno_report.rb
@@ -146,7 +146,7 @@ module Reports
 
       policy_contract_result = AcaEntities::Contracts::Policies::PolicyContract.new.call(JSON.parse(fetched_policy.payload))
       if policy_contract_result.failure?
-        @logger.info "Policy contract failure: #{policy_contract_result.errors} for record row #{@rcni_row}"
+        @logger.error "Policy contract failure: #{policy_contract_result.errors} for record row #{@rcni_row}"
       end
 
       policy_entity = AcaEntities::Policies::Policy.new(policy_contract_result.to_h)

--- a/app/operations/reports/generate_rcno_report.rb
+++ b/app/operations/reports/generate_rcno_report.rb
@@ -143,12 +143,16 @@ module Reports
         @overall_flag = "R"
         return [nil, nil, nil]
       end
+
       policy_contract_result = AcaEntities::Contracts::Policies::PolicyContract.new.call(JSON.parse(fetched_policy.payload))
-      return [nil, nil, nil] if policy_contract_result.failure?
+      if policy_contract_result.failure?
+        @logger.info "Policy contract failure: #{policy_contract_result.errors} for record row #{@rcni_row}"
+      end
 
       policy_entity = AcaEntities::Policies::Policy.new(policy_contract_result.to_h)
+      @logger.info "No member found due to blank policy entity for #{@rcni_row}" if policy_entity.blank?
 
-      member = policy_entity.enrollees.detect { |enrollee| enrollee.hbx_member_id == @rcni_row[17] }
+      member = policy_entity&.enrollees&.detect { |enrollee| enrollee.hbx_member_id == @rcni_row[17] }
       if member.present?
         segments = member.segments
         @overall_flag = "R" if segments.blank?


### PR DESCRIPTION
Modifying report to continue when policy contract fails. Instead, 
- log the contract failure
- log if member is blank due to blank policy_entity 
- Add safety check for if policy_entity is blank so that member returns nil rather than error in that case

By logging policy contract failure instead of returning nil, we fix error where nil policy, member, or segment values are being passed without getting flag correctly set.

https://www.pivotaltracker.com/n/projects/2502930/stories/185864723