### PR TITLE
updating functions to return if U flag is present

### DIFF
--- a/app/operations/reports/generate_rcno_report.rb
+++ b/app/operations/reports/generate_rcno_report.rb
@@ -340,7 +340,7 @@ module Reports
     end
 
     def exchange_assigned_subscriber_id
-      return [nil, @rcni_row[16], "U"] if @rcni_row[16].blank? && @overall_flag == "U"
+      return [nil, @rcni_row[16], "U"] if @overall_flag == "U"
       # If Subscriber, Member, or Policy are not found
       return [nil, @rcni_row[16], "D"] if @overall_flag == "R"
 
@@ -359,7 +359,7 @@ module Reports
     end
 
     def exchange_assigned_member_id
-      return [nil, @rcni_row[17], "U"] if @rcni_row[17].blank? && @overall_flag == "U"
+      return [nil, @rcni_row[17], "U"] if @overall_flag == "U"
       # If Subscriber, Member, or Policy are not found
       return [nil, @rcni_row[17], "D"] if @overall_flag == "R"
 
@@ -435,7 +435,7 @@ module Reports
     end
 
     def exchange_assigned_policy_number
-      return [nil, @rcni_row[20], "U"] if @rcni_row[20].blank? && @overall_flag == "U"
+      return [nil, @rcni_row[20], "U"] if @overall_flag == "U"
       # If Subscriber, Member, or Policy are not found
       return [nil, @rcni_row[20], "D"] if @overall_flag == "R"
 
@@ -618,7 +618,7 @@ module Reports
     end
 
     def benefit_start_date
-      return [nil, @rcni_row[37], "U"] if @rcni_row[37].blank? && @overall_flag == "U"
+      return [nil, @rcni_row[37], "U"] if @overall_flag == "U"
 
       # If Subscriber, Member, or Policy are not found
       return [nil, @rcni_row[37], "D"] if @overall_flag == "R"


### PR DESCRIPTION
Currently we check if rcni rows are blank to exit functions when overall flag is U.  We don't need this extra check as the row will just return nil if that piece is blank.  With this check, the function will continue even though there is no policy present and cause an error when we call a function on the policy