### PR TITLE
calculates pediatric dental premium for children aged less than 19 at start of coverage for family rated plans

### DIFF
--- a/spec/operations/irs_groups/calculate_dental_premium_for_enrolled_children_spec.rb
+++ b/spec/operations/irs_groups/calculate_dental_premium_for_enrolled_children_spec.rb
@@ -93,4 +93,18 @@ RSpec.describe IrsGroups::CalculateDentalPremiumForEnrolledChildren, type: :mode
       expect(subject.success.to_f).to eq(primary_enrollee_two_dependent)
     end
   end
+
+  context 'with only 1 dependent who was 19 at start of coverage' do
+    let(:dependent5) do
+      FactoryBot.build(:enrolled_member,
+                       person: FactoryBot.create(:people_person),
+                       dob: Date.new(year - 19, 1, 1))
+    end
+
+    let(:dependents) { [dependent5] }
+
+    it 'return should 0' do
+      expect(subject.success.to_f).to eq(0.0)
+    end
+  end
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186496208